### PR TITLE
Fix docker compose file extension in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ As we are seeing a lot of technological enhancements in the industry in the past
 ## How to run the project
 VulnerableApp-facade is a farm of vulnerable applications where each application runs as a docker container. VulnerableApp-facade has `docker-compose.yml` file which contains docker configuration of other vulnerable applications along with docker configuration of VulnerableApp-facade. 
 ### Simple Start ###
-In order to run entire suit please download the [docker-compose.xml](https://github.com/SasanLabs/VulnerableApp-facade/blob/main/docker-compose.yml) and run the following command from terminal:
+In order to run entire suit please download and install [Docker Compose](https://docs.docker.com/compose/install/). After installation, please copy the [docker-compose.yml](https://github.com/SasanLabs/VulnerableApp-facade/blob/main/docker-compose.yml) and run the following command from terminal:
 ``` docker-compose up ```
 Then naviate to ``` http://localhost:8080 ``` to play with the application
 
 ### Advanced Start ###
-As [docker-compose.xml](https://github.com/SasanLabs/VulnerableApp-facade/blob/main/docker-compose.yml) contains all the applications which adhere to the schema of VulnerableApp-facade so in cause you are looking for specific vulnerable applications like only Java related vulnerable applications then remove other vulnerable applications from [docker-compose.xml](https://github.com/SasanLabs/VulnerableApp-facade/blob/main/docker-compose.yml) and then run steps as mentioned in the [Simple start step](#simple-start).
+As [docker-compose.yml](https://github.com/SasanLabs/VulnerableApp-facade/blob/main/docker-compose.yml) contains all the applications which adhere to the schema of VulnerableApp-facade so in cause you are looking for specific vulnerable applications like only Java related vulnerable applications then remove other vulnerable applications from [docker-compose.yml](https://github.com/SasanLabs/VulnerableApp-facade/blob/main/docker-compose.yml) and then run steps as mentioned in the [Simple start step](#simple-start).
 
 ## How to Contribute to the project
 VulnerableApp-facade have majorly 2 components:


### PR DESCRIPTION
Using `.xml` as file extension after copying the file and running `docker-compose up` can throw error - 
```
ERROR: 
        Can't find a suitable configuration file in this directory or any
        parent. Are you in the right directory?

        Supported filenames: docker-compose.yml, docker-compose.yaml, compose.yml, compose.yaml
```

Just the README had the issue which lead to the confusion.
Signed-off-by: Prince Mendiratta <prince.mendiratta@getastra.com>