### PR TITLE
Add unit tests for App.tsx

### DIFF
--- a/facade-app/src/App.tsx
+++ b/facade-app/src/App.tsx
@@ -21,108 +21,6 @@ export default class App extends React.Component {
     showHints: false,
   };
 
-  _getResourcesInformationsForLevel(levelInformationRes: any) {
-    let resourceInformationHtml = {
-      isAbsolute:
-        levelInformationRes["resourceInformation"]["htmlResource"][
-          "isAbsolute"
-        ],
-      uri: levelInformationRes["resourceInformation"]["htmlResource"]["uri"],
-    };
-
-    let staticResourceInformation = [];
-    for (let staticResourceInformationIndexRes in levelInformationRes[
-      "levels"
-    ]) {
-      let staticResourceInformationRes =
-        levelInformationRes["levels"][staticResourceInformationIndexRes];
-      staticResourceInformation.push({
-        isAbsolute: staticResourceInformationRes["isAbsolute"],
-        uri: staticResourceInformationRes["uri"],
-        resourceType: staticResourceInformationRes["resourceType"],
-      });
-    }
-    return {
-      resourceInformationHtml: resourceInformationHtml,
-      staticResourceInformation: staticResourceInformation,
-    };
-  }
-
-  _getHintsForLevel(levelInformationRes: any) {
-    let hints = [];
-    for (let hintIndexRes in levelInformationRes["hints"]) {
-      let hintRes = levelInformationRes["hints"][hintIndexRes];
-      let vulnerabilityTypes = [];
-      for (let vulnerabilityTypeIndexRes in hintRes["vulnerabilityTypes"]) {
-        vulnerabilityTypes.push({
-          identifierType:
-            hintRes["vulnerabilityTypes"][vulnerabilityTypeIndexRes][
-              "identifierType"
-            ],
-          value:
-            hintRes["vulnerabilityTypes"][vulnerabilityTypeIndexRes]["value"],
-        });
-      }
-      let hint = {
-        description: hintRes[hintIndexRes],
-        vulnerabilityTypes: vulnerabilityTypes,
-      };
-      hints.push(hint);
-    }
-    return hints;
-  }
-
-  _getVulnerabilityTypesForLevel(vulnerabilityDefinitionsRes: any) {
-    let vulnerabilityTypes = [];
-    for (let vulnerabilityTypeIndexRes in vulnerabilityDefinitionsRes[
-      "vulnerabilityTypes"
-    ]) {
-      vulnerabilityTypes.push({
-        identifierType:
-          vulnerabilityDefinitionsRes["vulnerabilityTypes"][
-            vulnerabilityTypeIndexRes
-          ]["identifierType"],
-        value:
-          vulnerabilityDefinitionsRes["vulnerabilityTypes"][
-            vulnerabilityTypeIndexRes
-          ]["value"],
-      });
-    }
-    return vulnerabilityTypes;
-  }
-
-  _populateLevelsForVulnerability(
-    vulnerabilityDefinitionsRes: any,
-    vulnerabilityDefinitionIndexRes: string
-  ) {
-    let levels = [];
-    for (let vulnerabilityLevelIndexRes in vulnerabilityDefinitionsRes[
-      vulnerabilityDefinitionIndexRes
-    ]["levels"]) {
-      let levelInformationRes =
-        vulnerabilityDefinitionsRes[vulnerabilityDefinitionIndexRes]["levels"][
-          vulnerabilityLevelIndexRes
-        ];
-      //Hint population
-      let hints = this._getHintsForLevel(levelInformationRes);
-      // Resource population
-      let resourceInformations =
-        this._getResourcesInformationsForLevel(levelInformationRes);
-
-      let levelInformation = {
-        levelIdentifier: levelInformationRes["levelIdentifier"],
-        variant: levelInformationRes["variant"],
-        hints: hints,
-        resourceInformation: {
-          htmlResource: resourceInformations.resourceInformationHtml,
-          staticResources: resourceInformations.staticResourceInformation,
-        },
-      };
-      levels.push(levelInformation);
-      return levels;
-    }
-  }
-
   _populateGlobalState(
     vulnerabilityDefinitionResponse: VulnerabilityDefinitionResponse
   ) {
@@ -134,24 +32,7 @@ export default class App extends React.Component {
       let applicationDataArray = [];
       for (let vulnerableAppRes in applicationsDataRes) {
         let vulnerabilityDefinitionsRes = applicationsDataRes[vulnerableAppRes];
-        let vulnerabilityDefinitions = [];
-        for (let vulnerabilityDefinitionIndexRes in vulnerabilityDefinitionsRes) {
-          let levels = this._populateLevelsForVulnerability(
-            vulnerabilityDefinitionsRes,
-            vulnerabilityDefinitionIndexRes
-          );
-          let vulnerabilityTypes = this._getVulnerabilityTypesForLevel(
-            vulnerabilityDefinitionIndexRes
-          );
-          let vulnerabilityDefinition = {
-            name: vulnerabilityDefinitionsRes["name"],
-            id: vulnerabilityDefinitionsRes["id"],
-            description: vulnerabilityDefinitionsRes["description"],
-            vulnerabilityTypes: vulnerabilityTypes,
-            levels: levels,
-          };
-          vulnerabilityDefinitions.push(vulnerabilityDefinition);
-        }
+
         applicationDataArray.push({
           applicationName: vulnerableAppRes,
           vulnerabilityDefinitions: vulnerabilityDefinitionsRes,

--- a/facade-app/src/test/App.test.tsx
+++ b/facade-app/src/test/App.test.tsx
@@ -1,0 +1,92 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { getResource } from "../Utilities/Utils";
+import testFixture from "./fixtures";
+
+import App from "../App";
+
+jest.mock("../Utilities/Utils");
+
+describe("App", () => {
+  const _renderAppFully = () => {
+    //mock getResource since it will not work during testing
+    (getResource as jest.Mock).mockImplementation(
+      (uri: string, callback: Function, isJson: boolean) => {
+        //testFixture structure does not match the web response.
+        //so, we restructure it
+        const response = {
+          VulnerableApp:
+            testFixture.applicationData[0].vulnerabilityDefinitions,
+          "VulnerableApp-jsp":
+            testFixture.applicationData[1].vulnerabilityDefinitions,
+          "VulnerableApp-php":
+            testFixture.applicationData[2].vulnerabilityDefinitions,
+        };
+
+        callback({ isSuccessful: true, data: response });
+      }
+    );
+
+    return render(<App />);
+  };
+
+  const _renderAppFail = () => {
+    (getResource as jest.Mock).mockImplementation(
+      (uri: string, callback: Function, isJson: boolean) => {
+        callback({ isSuccessful: false, error: "error" });
+      }
+    );
+
+    return render(<App />);
+  };
+
+  const _renderAppNull = () => {
+    (getResource as jest.Mock).mockImplementation(
+      (uri: string, callback: Function, isJson: boolean) => {
+        callback({ isSuccessful: true, data: null });
+      }
+    );
+
+    return render(<App />);
+  };
+
+  const _renderAppEmpty = () => {
+    (getResource as jest.Mock).mockImplementation(
+      (uri: string, callback: Function, isJson: boolean) => {
+        callback({ isSuccessful: true, data: {} });
+      }
+    );
+
+    return render(<App />);
+  };
+
+  it("renders correctly", async () => {
+    expect(_renderAppFully().container).toMatchSnapshot();
+  });
+
+  it("renders content on nav item click", () => {
+    _renderAppFully();
+
+    fireEvent(
+      screen.getByTestId("VulnerableApp.CommandInjection.LEVEL_1"),
+      new MouseEvent("click", { bubbles: true, cancelable: true })
+    );
+    const content = screen.getByTestId("VULNERABILITY_CONTENT_DESCRIPTION");
+    expect(content).toBeInTheDocument();
+  });
+
+  it("does not render nav when data is null", async () => {
+    _renderAppNull();
+    expect(screen.queryByTestId(/LEFT_NAV_CONTAINER/i)).toBeNull();
+  });
+
+  it("does not render nav when getResource failed", async () => {
+    _renderAppFail();
+    expect(screen.queryByTestId(/LEFT_NAV_CONTAINER/i)).toBeNull();
+  });
+
+  it("does not render nav items when empty", async () => {
+    _renderAppEmpty();
+    expect(screen.queryByTestId(/VulnerableApp.CommandInjection/i)).toBeNull();
+  });
+});

--- a/facade-app/src/test/__snapshots__/App.test.tsx.snap
+++ b/facade-app/src/test/__snapshots__/App.test.tsx.snap
@@ -1,0 +1,2293 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`App renders correctly 1`] = `
+<div>
+  <div
+    class="rs-container show-container"
+  >
+    <div
+      class="rs-header"
+    >
+      <div
+        class="rs-navbar rs-navbar-inverse"
+        role="navigation"
+      >
+        <div
+          class="rs-navbar-header"
+        >
+          <img
+            alt="vulnerable app logo"
+            height="55"
+            src="Logo.png"
+            width="55"
+          />
+        </div>
+        <div
+          class="rs-navbar-body"
+        >
+          <div
+            class="rs-nav rs-nav-default rs-navbar-nav rs-nav-horizontal"
+          >
+            <ul>
+              <li
+                class="rs-nav-item"
+              >
+                <a
+                  class="rs-nav-item-content"
+                  role="button"
+                  tabindex="0"
+                >
+                  <b>
+                    Owasp VulnerableApp-Facade
+                  </b>
+                  <span
+                    class="rs-ripple-pond"
+                  >
+                    <span
+                      class="rs-ripple"
+                    />
+                  </span>
+                </a>
+              </li>
+            </ul>
+          </div>
+          <div
+            class="rs-nav rs-nav-default rs-navbar-nav rs-navbar-right rs-nav-horizontal"
+          >
+            <ul>
+              <li
+                class="rs-nav-item"
+              >
+                <a
+                  class="rs-nav-item-content"
+                  role="button"
+                  tabindex="0"
+                >
+                  <i
+                    class="rs-icon rs-icon-home"
+                    role="img"
+                  />
+                  Home
+                  <span
+                    class="rs-ripple-pond"
+                  >
+                    <span
+                      class="rs-ripple"
+                    />
+                  </span>
+                </a>
+              </li>
+              <li
+                class="rs-nav-item"
+              >
+                <a
+                  class="rs-nav-item-content"
+                  role="button"
+                  tabindex="0"
+                >
+                  About Us
+                  <span
+                    class="rs-ripple-pond"
+                  >
+                    <span
+                      class="rs-ripple"
+                    />
+                  </span>
+                </a>
+              </li>
+              <a
+                href="https://github.com/SasanLabs/VulnerableApp-facade"
+              >
+                <li
+                  class="rs-nav-item"
+                >
+                  <a
+                    class="rs-nav-item-content"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <i
+                      class="rs-icon rs-icon-github"
+                      role="img"
+                    />
+                    Github
+                    <span
+                      class="rs-ripple-pond"
+                    >
+                      <span
+                        class="rs-ripple"
+                      />
+                    </span>
+                  </a>
+                </li>
+              </a>
+              <li
+                class="rs-dropdown rs-dropdown-placement-bottom-start"
+                role="menu"
+              >
+                <ul
+                  class="rs-dropdown-menu"
+                  role="menu"
+                >
+                  <a
+                    href="https://github.com/SasanLabs/VulnerableApp"
+                  >
+                    <li
+                      class="rs-dropdown-item rs-dropdown-item-with-icon"
+                    >
+                      <a
+                        class="rs-dropdown-item-content"
+                        tabindex="-1"
+                      >
+                        <i
+                          class="rs-dropdown-item-menu-icon rs-icon rs-icon-github"
+                          role="img"
+                        />
+                        Owasp VulnerableApp
+                      </a>
+                    </li>
+                  </a>
+                  <a
+                    href="https://github.com/SasanLabs/owasp-zap-jwt-addon"
+                  >
+                     
+                    <li
+                      class="rs-dropdown-item rs-dropdown-item-with-icon"
+                    >
+                      <a
+                        class="rs-dropdown-item-content"
+                        tabindex="-1"
+                      >
+                        <i
+                          class="rs-dropdown-item-menu-icon rs-icon rs-icon-github"
+                          role="img"
+                        />
+                        ZAP JWT Addon
+                      </a>
+                    </li>
+                  </a>
+                  <a
+                    href="https://github.com/SasanLabs/owasp-zap-fileupload-addon"
+                  >
+                    <li
+                      class="rs-dropdown-item rs-dropdown-item-with-icon"
+                    >
+                      <a
+                        class="rs-dropdown-item-content"
+                        tabindex="-1"
+                      >
+                        <i
+                          class="rs-dropdown-item-menu-icon rs-icon rs-icon-github"
+                          role="img"
+                        />
+                        ZAP FileUpload Addon
+                      </a>
+                    </li>
+                  </a>
+                </ul>
+                <a
+                  class="rs-btn rs-btn-subtle rs-dropdown-toggle"
+                  tabindex="0"
+                >
+                  Projects by SasanLabs
+                  <span
+                    class="rs-dropdown-toggle-caret"
+                  />
+                  <span
+                    class="rs-ripple-pond"
+                  >
+                    <span
+                      class="rs-ripple"
+                    />
+                  </span>
+                </a>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="rs-container show-container rs-container-has-sidebar"
+      style="display: flex; width: 100vw;"
+    >
+      <div
+        class="rs-sidebar"
+        style="flex: 0 0 260px; width: 260px;"
+      >
+        <div
+          data-testid="LEFT_NAV_CONTAINER"
+        >
+          <div
+            class="rs-sidenav rs-sidenav-default rs-sidenav-collapse-in"
+            role="navigation"
+          >
+            <div
+              class="rs-sidenav-body"
+            >
+              <div
+                class="rs-nav rs-nav-default rs-sidenav-nav rs-nav-vertical"
+              >
+                <ul>
+                  <li
+                    class="rs-dropdown VulnerableApp-Facade-LeftNav-Application rs-dropdown-placement-bottom-start rs-dropdown-expand"
+                    role="menu"
+                  >
+                    <ul
+                      class="rs-dropdown-menu rs-dropdown-menu-collapse-in"
+                      role="menu"
+                    >
+                      <li
+                        class="rs-dropdown-item-divider"
+                        role="separator"
+                      />
+                      <div
+                        class="rs-dropdown VulnerableApp-Facade-LeftNav-Vulnerability-Level rs-dropdown-placement-bottom-start rs-dropdown-collapse"
+                        role="menu"
+                      >
+                        <ul
+                          class="rs-dropdown-menu rs-dropdown-menu-collapse-out"
+                          role="menu"
+                        >
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.CommandInjection.LEVEL_1"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_1
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.CommandInjection.LEVEL_2"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_2
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.CommandInjection.LEVEL_3"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_3
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.CommandInjection.LEVEL_4"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_4
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.CommandInjection.LEVEL_5"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_5
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.CommandInjection.LEVEL_6"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-lock"
+                              />
+                              LEVEL_6
+                            </a>
+                          </li>
+                        </ul>
+                        <a
+                          class="rs-btn rs-btn-subtle rs-dropdown-toggle"
+                          data-testid="VulnerableApp.CommandInjection"
+                          tabindex="0"
+                        >
+                          CommandInjection
+                          <span
+                            class="rs-dropdown-toggle-caret"
+                          />
+                          <span
+                            class="rs-ripple-pond"
+                          >
+                            <span
+                              class="rs-ripple"
+                            />
+                          </span>
+                        </a>
+                      </div>
+                      <div
+                        class="rs-dropdown VulnerableApp-Facade-LeftNav-Vulnerability-Level rs-dropdown-placement-bottom-start rs-dropdown-collapse"
+                        role="menu"
+                      >
+                        <ul
+                          class="rs-dropdown-menu rs-dropdown-menu-collapse-out"
+                          role="menu"
+                        >
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.UnrestrictedFileUpload.LEVEL_1"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_1
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.UnrestrictedFileUpload.LEVEL_2"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_2
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.UnrestrictedFileUpload.LEVEL_3"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_3
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.UnrestrictedFileUpload.LEVEL_4"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_4
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.UnrestrictedFileUpload.LEVEL_5"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_5
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.UnrestrictedFileUpload.LEVEL_6"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_6
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.UnrestrictedFileUpload.LEVEL_7"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_7
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.UnrestrictedFileUpload.LEVEL_8"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_8
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.UnrestrictedFileUpload.LEVEL_9"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-lock"
+                              />
+                              LEVEL_9
+                            </a>
+                          </li>
+                        </ul>
+                        <a
+                          class="rs-btn rs-btn-subtle rs-dropdown-toggle"
+                          data-testid="VulnerableApp.UnrestrictedFileUpload"
+                          tabindex="0"
+                        >
+                          UnrestrictedFileUpload
+                          <span
+                            class="rs-dropdown-toggle-caret"
+                          />
+                          <span
+                            class="rs-ripple-pond"
+                          >
+                            <span
+                              class="rs-ripple"
+                            />
+                          </span>
+                        </a>
+                      </div>
+                      <div
+                        class="rs-dropdown VulnerableApp-Facade-LeftNav-Vulnerability-Level rs-dropdown-placement-bottom-start rs-dropdown-collapse"
+                        role="menu"
+                      >
+                        <ul
+                          class="rs-dropdown-menu rs-dropdown-menu-collapse-out"
+                          role="menu"
+                        >
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.JWTVulnerability.LEVEL_1"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_1
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.JWTVulnerability.LEVEL_2"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_2
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.JWTVulnerability.LEVEL_3"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_3
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.JWTVulnerability.LEVEL_4"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_4
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.JWTVulnerability.LEVEL_5"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_5
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.JWTVulnerability.LEVEL_6"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_6
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.JWTVulnerability.LEVEL_7"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_7
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.JWTVulnerability.LEVEL_8"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_8
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.JWTVulnerability.LEVEL_9"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_9
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.JWTVulnerability.LEVEL_10"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_10
+                            </a>
+                          </li>
+                        </ul>
+                        <a
+                          class="rs-btn rs-btn-subtle rs-dropdown-toggle"
+                          data-testid="VulnerableApp.JWTVulnerability"
+                          tabindex="0"
+                        >
+                          JWTVulnerability
+                          <span
+                            class="rs-dropdown-toggle-caret"
+                          />
+                          <span
+                            class="rs-ripple-pond"
+                          >
+                            <span
+                              class="rs-ripple"
+                            />
+                          </span>
+                        </a>
+                      </div>
+                      <div
+                        class="rs-dropdown VulnerableApp-Facade-LeftNav-Vulnerability-Level rs-dropdown-placement-bottom-start rs-dropdown-collapse"
+                        role="menu"
+                      >
+                        <ul
+                          class="rs-dropdown-menu rs-dropdown-menu-collapse-out"
+                          role="menu"
+                        >
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.Http3xxStatusCodeBasedInjection.LEVEL_1"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_1
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.Http3xxStatusCodeBasedInjection.LEVEL_2"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_2
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.Http3xxStatusCodeBasedInjection.LEVEL_3"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_3
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.Http3xxStatusCodeBasedInjection.LEVEL_4"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_4
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.Http3xxStatusCodeBasedInjection.LEVEL_5"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_5
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.Http3xxStatusCodeBasedInjection.LEVEL_6"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_6
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.Http3xxStatusCodeBasedInjection.LEVEL_7"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_7
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.Http3xxStatusCodeBasedInjection.LEVEL_8"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_8
+                            </a>
+                          </li>
+                        </ul>
+                        <a
+                          class="rs-btn rs-btn-subtle rs-dropdown-toggle"
+                          data-testid="VulnerableApp.Http3xxStatusCodeBasedInjection"
+                          tabindex="0"
+                        >
+                          Http3xxStatusCodeBasedInjection
+                          <span
+                            class="rs-dropdown-toggle-caret"
+                          />
+                          <span
+                            class="rs-ripple-pond"
+                          >
+                            <span
+                              class="rs-ripple"
+                            />
+                          </span>
+                        </a>
+                      </div>
+                      <div
+                        class="rs-dropdown VulnerableApp-Facade-LeftNav-Vulnerability-Level rs-dropdown-placement-bottom-start rs-dropdown-collapse"
+                        role="menu"
+                      >
+                        <ul
+                          class="rs-dropdown-menu rs-dropdown-menu-collapse-out"
+                          role="menu"
+                        >
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.PathTraversal.LEVEL_1"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_1
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.PathTraversal.LEVEL_2"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_2
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.PathTraversal.LEVEL_3"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_3
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.PathTraversal.LEVEL_4"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_4
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.PathTraversal.LEVEL_5"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_5
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.PathTraversal.LEVEL_6"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_6
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.PathTraversal.LEVEL_7"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_7
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.PathTraversal.LEVEL_8"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_8
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.PathTraversal.LEVEL_9"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_9
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.PathTraversal.LEVEL_10"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_10
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.PathTraversal.LEVEL_11"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_11
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.PathTraversal.LEVEL_12"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_12
+                            </a>
+                          </li>
+                        </ul>
+                        <a
+                          class="rs-btn rs-btn-subtle rs-dropdown-toggle"
+                          data-testid="VulnerableApp.PathTraversal"
+                          tabindex="0"
+                        >
+                          PathTraversal
+                          <span
+                            class="rs-dropdown-toggle-caret"
+                          />
+                          <span
+                            class="rs-ripple-pond"
+                          >
+                            <span
+                              class="rs-ripple"
+                            />
+                          </span>
+                        </a>
+                      </div>
+                      <div
+                        class="rs-dropdown VulnerableApp-Facade-LeftNav-Vulnerability-Level rs-dropdown-placement-bottom-start rs-dropdown-collapse"
+                        role="menu"
+                      >
+                        <ul
+                          class="rs-dropdown-menu rs-dropdown-menu-collapse-out"
+                          role="menu"
+                        >
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.RemoteFileInclusion.LEVEL_1"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_1
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.RemoteFileInclusion.LEVEL_2"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_2
+                            </a>
+                          </li>
+                        </ul>
+                        <a
+                          class="rs-btn rs-btn-subtle rs-dropdown-toggle"
+                          data-testid="VulnerableApp.RemoteFileInclusion"
+                          tabindex="0"
+                        >
+                          RemoteFileInclusion
+                          <span
+                            class="rs-dropdown-toggle-caret"
+                          />
+                          <span
+                            class="rs-ripple-pond"
+                          >
+                            <span
+                              class="rs-ripple"
+                            />
+                          </span>
+                        </a>
+                      </div>
+                      <div
+                        class="rs-dropdown VulnerableApp-Facade-LeftNav-Vulnerability-Level rs-dropdown-placement-bottom-start rs-dropdown-collapse"
+                        role="menu"
+                      >
+                        <ul
+                          class="rs-dropdown-menu rs-dropdown-menu-collapse-out"
+                          role="menu"
+                        >
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.BlindSQLInjectionVulnerability.LEVEL_1"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_1
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.BlindSQLInjectionVulnerability.LEVEL_2"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_2
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.BlindSQLInjectionVulnerability.LEVEL_3"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-lock"
+                              />
+                              LEVEL_3
+                            </a>
+                          </li>
+                        </ul>
+                        <a
+                          class="rs-btn rs-btn-subtle rs-dropdown-toggle"
+                          data-testid="VulnerableApp.BlindSQLInjectionVulnerability"
+                          tabindex="0"
+                        >
+                          BlindSQLInjectionVulnerability
+                          <span
+                            class="rs-dropdown-toggle-caret"
+                          />
+                          <span
+                            class="rs-ripple-pond"
+                          >
+                            <span
+                              class="rs-ripple"
+                            />
+                          </span>
+                        </a>
+                      </div>
+                      <div
+                        class="rs-dropdown VulnerableApp-Facade-LeftNav-Vulnerability-Level rs-dropdown-placement-bottom-start rs-dropdown-collapse"
+                        role="menu"
+                      >
+                        <ul
+                          class="rs-dropdown-menu rs-dropdown-menu-collapse-out"
+                          role="menu"
+                        >
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.ErrorBasedSQLInjectionVulnerability.LEVEL_1"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_1
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.ErrorBasedSQLInjectionVulnerability.LEVEL_2"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_2
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.ErrorBasedSQLInjectionVulnerability.LEVEL_3"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_3
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.ErrorBasedSQLInjectionVulnerability.LEVEL_4"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_4
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.ErrorBasedSQLInjectionVulnerability.LEVEL_5"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-lock"
+                              />
+                              LEVEL_5
+                            </a>
+                          </li>
+                        </ul>
+                        <a
+                          class="rs-btn rs-btn-subtle rs-dropdown-toggle"
+                          data-testid="VulnerableApp.ErrorBasedSQLInjectionVulnerability"
+                          tabindex="0"
+                        >
+                          ErrorBasedSQLInjectionVulnerability
+                          <span
+                            class="rs-dropdown-toggle-caret"
+                          />
+                          <span
+                            class="rs-ripple-pond"
+                          >
+                            <span
+                              class="rs-ripple"
+                            />
+                          </span>
+                        </a>
+                      </div>
+                      <div
+                        class="rs-dropdown VulnerableApp-Facade-LeftNav-Vulnerability-Level rs-dropdown-placement-bottom-start rs-dropdown-collapse"
+                        role="menu"
+                      >
+                        <ul
+                          class="rs-dropdown-menu rs-dropdown-menu-collapse-out"
+                          role="menu"
+                        >
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.UnionBasedSQLInjectionVulnerability.LEVEL_1"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_1
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.UnionBasedSQLInjectionVulnerability.LEVEL_2"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_2
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.UnionBasedSQLInjectionVulnerability.LEVEL_3"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-lock"
+                              />
+                              LEVEL_3
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.UnionBasedSQLInjectionVulnerability.LEVEL_4"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-lock"
+                              />
+                              LEVEL_4
+                            </a>
+                          </li>
+                        </ul>
+                        <a
+                          class="rs-btn rs-btn-subtle rs-dropdown-toggle"
+                          data-testid="VulnerableApp.UnionBasedSQLInjectionVulnerability"
+                          tabindex="0"
+                        >
+                          UnionBasedSQLInjectionVulnerability
+                          <span
+                            class="rs-dropdown-toggle-caret"
+                          />
+                          <span
+                            class="rs-ripple-pond"
+                          >
+                            <span
+                              class="rs-ripple"
+                            />
+                          </span>
+                        </a>
+                      </div>
+                      <div
+                        class="rs-dropdown VulnerableApp-Facade-LeftNav-Vulnerability-Level rs-dropdown-placement-bottom-start rs-dropdown-collapse"
+                        role="menu"
+                      >
+                        <ul
+                          class="rs-dropdown-menu rs-dropdown-menu-collapse-out"
+                          role="menu"
+                        >
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.SSRFVulnerability.LEVEL_1"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_1
+                            </a>
+                          </li>
+                        </ul>
+                        <a
+                          class="rs-btn rs-btn-subtle rs-dropdown-toggle"
+                          data-testid="VulnerableApp.SSRFVulnerability"
+                          tabindex="0"
+                        >
+                          SSRFVulnerability
+                          <span
+                            class="rs-dropdown-toggle-caret"
+                          />
+                          <span
+                            class="rs-ripple-pond"
+                          >
+                            <span
+                              class="rs-ripple"
+                            />
+                          </span>
+                        </a>
+                      </div>
+                      <div
+                        class="rs-dropdown VulnerableApp-Facade-LeftNav-Vulnerability-Level rs-dropdown-placement-bottom-start rs-dropdown-collapse"
+                        role="menu"
+                      >
+                        <ul
+                          class="rs-dropdown-menu rs-dropdown-menu-collapse-out"
+                          role="menu"
+                        >
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.PersistentXSSInHTMLTagVulnerability.LEVEL_1"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_1
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.PersistentXSSInHTMLTagVulnerability.LEVEL_2"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_2
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.PersistentXSSInHTMLTagVulnerability.LEVEL_3"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_3
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.PersistentXSSInHTMLTagVulnerability.LEVEL_4"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_4
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.PersistentXSSInHTMLTagVulnerability.LEVEL_5"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_5
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.PersistentXSSInHTMLTagVulnerability.LEVEL_6"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_6
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.PersistentXSSInHTMLTagVulnerability.LEVEL_7"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-lock"
+                              />
+                              LEVEL_7
+                            </a>
+                          </li>
+                        </ul>
+                        <a
+                          class="rs-btn rs-btn-subtle rs-dropdown-toggle"
+                          data-testid="VulnerableApp.PersistentXSSInHTMLTagVulnerability"
+                          tabindex="0"
+                        >
+                          PersistentXSSInHTMLTagVulnerability
+                          <span
+                            class="rs-dropdown-toggle-caret"
+                          />
+                          <span
+                            class="rs-ripple-pond"
+                          >
+                            <span
+                              class="rs-ripple"
+                            />
+                          </span>
+                        </a>
+                      </div>
+                      <div
+                        class="rs-dropdown VulnerableApp-Facade-LeftNav-Vulnerability-Level rs-dropdown-placement-bottom-start rs-dropdown-collapse"
+                        role="menu"
+                      >
+                        <ul
+                          class="rs-dropdown-menu rs-dropdown-menu-collapse-out"
+                          role="menu"
+                        >
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.XSSWithHtmlTagInjection.LEVEL_1"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_1
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.XSSWithHtmlTagInjection.LEVEL_2"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_2
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.XSSWithHtmlTagInjection.LEVEL_3"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_3
+                            </a>
+                          </li>
+                        </ul>
+                        <a
+                          class="rs-btn rs-btn-subtle rs-dropdown-toggle"
+                          data-testid="VulnerableApp.XSSWithHtmlTagInjection"
+                          tabindex="0"
+                        >
+                          XSSWithHtmlTagInjection
+                          <span
+                            class="rs-dropdown-toggle-caret"
+                          />
+                          <span
+                            class="rs-ripple-pond"
+                          >
+                            <span
+                              class="rs-ripple"
+                            />
+                          </span>
+                        </a>
+                      </div>
+                      <div
+                        class="rs-dropdown VulnerableApp-Facade-LeftNav-Vulnerability-Level rs-dropdown-placement-bottom-start rs-dropdown-collapse"
+                        role="menu"
+                      >
+                        <ul
+                          class="rs-dropdown-menu rs-dropdown-menu-collapse-out"
+                          role="menu"
+                        >
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.XSSInImgTagAttribute.LEVEL_1"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_1
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.XSSInImgTagAttribute.LEVEL_2"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_2
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.XSSInImgTagAttribute.LEVEL_3"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_3
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.XSSInImgTagAttribute.LEVEL_4"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_4
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.XSSInImgTagAttribute.LEVEL_5"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_5
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.XSSInImgTagAttribute.LEVEL_6"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_6
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.XSSInImgTagAttribute.LEVEL_7"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-lock"
+                              />
+                              LEVEL_7
+                            </a>
+                          </li>
+                        </ul>
+                        <a
+                          class="rs-btn rs-btn-subtle rs-dropdown-toggle"
+                          data-testid="VulnerableApp.XSSInImgTagAttribute"
+                          tabindex="0"
+                        >
+                          XSSInImgTagAttribute
+                          <span
+                            class="rs-dropdown-toggle-caret"
+                          />
+                          <span
+                            class="rs-ripple-pond"
+                          >
+                            <span
+                              class="rs-ripple"
+                            />
+                          </span>
+                        </a>
+                      </div>
+                      <div
+                        class="rs-dropdown VulnerableApp-Facade-LeftNav-Vulnerability-Level rs-dropdown-placement-bottom-start rs-dropdown-collapse"
+                        role="menu"
+                      >
+                        <ul
+                          class="rs-dropdown-menu rs-dropdown-menu-collapse-out"
+                          role="menu"
+                        >
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.XXEVulnerability.LEVEL_1"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_1
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.XXEVulnerability.LEVEL_2"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_2
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.XXEVulnerability.LEVEL_3"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-lock"
+                              />
+                              LEVEL_3
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp.XXEVulnerability.LEVEL_4"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-lock"
+                              />
+                              LEVEL_4
+                            </a>
+                          </li>
+                        </ul>
+                        <a
+                          class="rs-btn rs-btn-subtle rs-dropdown-toggle"
+                          data-testid="VulnerableApp.XXEVulnerability"
+                          tabindex="0"
+                        >
+                          XXEVulnerability
+                          <span
+                            class="rs-dropdown-toggle-caret"
+                          />
+                          <span
+                            class="rs-ripple-pond"
+                          >
+                            <span
+                              class="rs-ripple"
+                            />
+                          </span>
+                        </a>
+                      </div>
+                    </ul>
+                    <a
+                      class="rs-btn rs-btn-subtle rs-dropdown-toggle"
+                      tabindex="0"
+                    >
+                      <i
+                        class="rs-icon rs-icon-server"
+                        role="img"
+                      />
+                      VulnerableApp
+                      <span
+                        class="rs-dropdown-toggle-caret"
+                      />
+                      <span
+                        class="rs-ripple-pond"
+                      >
+                        <span
+                          class="rs-ripple"
+                        />
+                      </span>
+                    </a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+          <div
+            class="rs-sidenav rs-sidenav-default rs-sidenav-collapse-in"
+            role="navigation"
+          >
+            <div
+              class="rs-sidenav-body"
+            >
+              <div
+                class="rs-nav rs-nav-default rs-sidenav-nav rs-nav-vertical"
+              >
+                <ul>
+                  <li
+                    class="rs-dropdown VulnerableApp-Facade-LeftNav-Application rs-dropdown-placement-bottom-start rs-dropdown-collapse"
+                    role="menu"
+                  >
+                    <ul
+                      class="rs-dropdown-menu rs-dropdown-menu-collapse-out"
+                      role="menu"
+                    >
+                      <li
+                        class="rs-dropdown-item-divider"
+                        role="separator"
+                      />
+                      <div
+                        class="rs-dropdown VulnerableApp-Facade-LeftNav-Vulnerability-Level rs-dropdown-placement-bottom-start rs-dropdown-collapse"
+                        role="menu"
+                      >
+                        <ul
+                          class="rs-dropdown-menu rs-dropdown-menu-collapse-out"
+                          role="menu"
+                        >
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp-jsp.FileUpload.LEVEL_1"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_1
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp-jsp.FileUpload.LEVEL_2"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_2
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp-jsp.FileUpload.LEVEL_3"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_3
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp-jsp.FileUpload.LEVEL_4"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_4
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp-jsp.FileUpload.LEVEL_5"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_5
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp-jsp.FileUpload.LEVEL_6"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_6
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp-jsp.FileUpload.LEVEL_7"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-lock"
+                              />
+                              LEVEL_7
+                            </a>
+                          </li>
+                        </ul>
+                        <a
+                          class="rs-btn rs-btn-subtle rs-dropdown-toggle"
+                          data-testid="VulnerableApp-jsp.FileUpload"
+                          tabindex="0"
+                        >
+                          FileUpload
+                          <span
+                            class="rs-dropdown-toggle-caret"
+                          />
+                          <span
+                            class="rs-ripple-pond"
+                          >
+                            <span
+                              class="rs-ripple"
+                            />
+                          </span>
+                        </a>
+                      </div>
+                    </ul>
+                    <a
+                      class="rs-btn rs-btn-subtle rs-dropdown-toggle"
+                      tabindex="0"
+                    >
+                      <i
+                        class="rs-icon rs-icon-server"
+                        role="img"
+                      />
+                      VulnerableApp-jsp
+                      <span
+                        class="rs-dropdown-toggle-caret"
+                      />
+                      <span
+                        class="rs-ripple-pond"
+                      >
+                        <span
+                          class="rs-ripple"
+                        />
+                      </span>
+                    </a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+          <div
+            class="rs-sidenav rs-sidenav-default rs-sidenav-collapse-in"
+            role="navigation"
+          >
+            <div
+              class="rs-sidenav-body"
+            >
+              <div
+                class="rs-nav rs-nav-default rs-sidenav-nav rs-nav-vertical"
+              >
+                <ul>
+                  <li
+                    class="rs-dropdown VulnerableApp-Facade-LeftNav-Application rs-dropdown-placement-bottom-start rs-dropdown-collapse"
+                    role="menu"
+                  >
+                    <ul
+                      class="rs-dropdown-menu rs-dropdown-menu-collapse-out"
+                      role="menu"
+                    >
+                      <li
+                        class="rs-dropdown-item-divider"
+                        role="separator"
+                      />
+                      <div
+                        class="rs-dropdown VulnerableApp-Facade-LeftNav-Vulnerability-Level rs-dropdown-placement-bottom-start rs-dropdown-collapse"
+                        role="menu"
+                      >
+                        <ul
+                          class="rs-dropdown-menu rs-dropdown-menu-collapse-out"
+                          role="menu"
+                        >
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp-php.FileUpload.LEVEL_1"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_1
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp-php.FileUpload.LEVEL_2"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_2
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp-php.FileUpload.LEVEL_3"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_3
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp-php.FileUpload.LEVEL_4"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_4
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp-php.FileUpload.LEVEL_5"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_5
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp-php.FileUpload.LEVEL_6"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_6
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp-php.FileUpload.LEVEL_7"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_7
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp-php.FileUpload.LEVEL_8"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_8
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp-php.FileUpload.LEVEL_9"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_9
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp-php.FileUpload.LEVEL_10"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_10
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp-php.FileUpload.LEVEL_11"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-unlock"
+                              />
+                              LEVEL_11
+                            </a>
+                          </li>
+                          <li
+                            class="rs-dropdown-item rs-dropdown-item-with-icon"
+                          >
+                            <a
+                              class="rs-dropdown-item-content"
+                              data-testid="VulnerableApp-php.FileUpload.LEVEL_12"
+                              tabindex="-1"
+                            >
+                              <i
+                                class="rs-dropdown-item-menu-icon rs-icon rs-icon-lock"
+                              />
+                              LEVEL_12
+                            </a>
+                          </li>
+                        </ul>
+                        <a
+                          class="rs-btn rs-btn-subtle rs-dropdown-toggle"
+                          data-testid="VulnerableApp-php.FileUpload"
+                          tabindex="0"
+                        >
+                          FileUpload
+                          <span
+                            class="rs-dropdown-toggle-caret"
+                          />
+                          <span
+                            class="rs-ripple-pond"
+                          >
+                            <span
+                              class="rs-ripple"
+                            />
+                          </span>
+                        </a>
+                      </div>
+                    </ul>
+                    <a
+                      class="rs-btn rs-btn-subtle rs-dropdown-toggle"
+                      tabindex="0"
+                    >
+                      <i
+                        class="rs-icon rs-icon-server"
+                        role="img"
+                      />
+                      VulnerableApp-php
+                      <span
+                        class="rs-dropdown-toggle-caret"
+                      />
+                      <span
+                        class="rs-ripple-pond"
+                      >
+                        <span
+                          class="rs-ripple"
+                        />
+                      </span>
+                    </a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="VulnerableApp-Facade-Info"
+      >
+        <div>
+          <div
+            class="rs-panel-group"
+          >
+            <div
+              data-testid="HOME_PAGE_MAIN_CONTAINER"
+            >
+              <div
+                class="VulnerableApp-Facade-HomePage-Content-Header rs-panel rs-panel-default"
+              >
+                <div
+                  class="rs-panel-heading"
+                  role="rowheader"
+                  tabindex="-1"
+                >
+                  Welcome to Owasp VulnerableApp-Facade
+                </div>
+                <div
+                  class="rs-panel-body"
+                >
+                  <div
+                    class="VulnerableApp-Facade-HomePage-Content"
+                    data-testid="HOME_PAGE_CONTENT_CONTAINER"
+                  >
+                    As we are seeing a lot of technological enhancements in the industry from past few years, these technical enhancements are solving one or the other problem however, with that they also bring few different vulnerabilities. Vulnerable Applications are generally written in one of the techstacks like either Node.js or Java with a SQL or NoSQL database etc and hence they are not able to expand to a whole new set of vulnerabilities which are present in other technologies. Also adding more vulnerabilities in a single vulnerable application makes it heavier and complex which finally makes it unmaintainable. So VulnerableApp-facade is built to solve this problem by building a distributed farm of Vulnerable Applications such that they can be built agnostic to tech stacks.
+                    <p>
+                      Following is the design diagram of Owasp VulnerableApp-Facade:
+                    </p>
+                    <img
+                      alt="Unable to lead the design diagram"
+                      src="/images/VulnerableApp-facade.jpeg"
+                      width="80%"
+                    />
+                    <p>
+                      Here VulnerableApp-Facade is running as a gateway or a proxy which is routing calls to actual Vulnerable Applications based on a criteria defined in the nginx configuration.
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="VulnerableApp-Facade-HomePage-Content-Header rs-panel rs-panel-default"
+                data-testid="HOME_PAGE_WARNING_CONTAINER"
+              >
+                <div
+                  class="rs-panel-heading"
+                  role="rowheader"
+                  tabindex="-1"
+                >
+                  Warning
+                </div>
+                <div
+                  class="rs-panel-body"
+                >
+                  <div
+                    class="VulnerableApp-Facade-HomePage-Content"
+                  >
+                    As VulnerableApp-Facade is a proxy wrapper over the actual Vulnerable Applications which can be very dangerous if exposed over the public internet. So we suggest you to please run it in local dev environments or environments without any public internet access.
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <footer
+      class="rs-footer"
+    >
+      <div
+        class="rs-navbar rs-navbar-default"
+        role="navigation"
+      >
+        <div
+          class="rs-navbar-body"
+          style="text-align: center; height: 30px; font-size: 15px;"
+        >
+          <div
+            data-testid="FOOTER_COPYRIGHT_TEXT"
+          >
+            © Copyright 
+            2022
+            , SasanLabs
+          </div>
+        </div>
+      </div>
+    </footer>
+  </div>
+</div>
+`;


### PR DESCRIPTION
For Issue #89 

I managed to get coverage to 95%

I am having problems getting the rest covered.
Specially on certain lines when it populates the`"levels"` and `"VulnerabilityTypes"`. You can see this on my CodeCov [report](https://app.codecov.io/github/lejara/VulnerableApp-facade/blob/issue%2389/facade-app/src/App.tsx).

I notice the global state prop `applicationData[n].vulnerabilityDefinitions` uses  `getResource()'s` response data directly, therefore most of the population work done are never used.

Reference:
https://github.com/SasanLabs/VulnerableApp-facade/blob/main/facade-app/src/App.tsx#L157

Unless i read this wrong.
Line 157 `vulnerabilityDefinitions` prop should be assgined to `vulnerabilityDefinitions` local var and not `vulnerabilityDefinitionsRes`.
Or not have the population code for `vulnerabilityDefinitions` local var at all.

Of course, removing said code will bring the coverage up to 100%.




