### PR TITLE
Add getUrlForVulnerability function to retrieve vulnerability URL

### DIFF
--- a/facade-app/public/GlobalUtility.js
+++ b/facade-app/public/GlobalUtility.js
@@ -71,3 +71,8 @@ function getUrlForVulnerabilityLevel() {
     details.activeVulnerabilityLevelIdentifier;
   return url;
 }
+
+function getUrlForVulnerability() {
+  let details = window.getCurrentVulnerabilityDetails();
+  return "/VulnerableApp/" + details.activeVulnerabilityIdentifier;
+}


### PR DESCRIPTION
This PR introduces the `getUrlForVulnerability`function, which enables retrieving the vulnerability URL. It is intended to support the changes proposed in https://github.com/SasanLabs/VulnerableApp/pull/534