### PR TITLE
Point the scanner merge at /scanner/dast and skip non-JSON responses (#122)

### DIFF
--- a/lua-modules/vulnerableapp_utility.lua
+++ b/lua-modules/vulnerableapp_utility.lua
@@ -1,27 +1,39 @@
 local vulnerableapp_utility = {}
 
+-- An app can answer 200 with a body that is not JSON. VulnerableApp-php does exactly that on the
+-- scanner endpoints, replying "/VulnerableApp-php/scanner/dast is not available" as text/html.
+-- Splicing such a body in produces a document that is not JSON at all, so the whole merged
+-- response becomes unreadable rather than one app being missing from it.
+local function carries_json(response)
+    if (not response or response.status ~= 200 or not response.body) then
+        return false
+    end
+    local first = response.body:match("^%s*(.)")
+    return first == "[" or first == "{"
+end
+
 function vulnerableapp_utility.merge_vulnerability_information(vulnerableAppResponse, vulnerableAppJspResponse, vulnerableAppPhpResponse, llmForgeResponse)
     local response = "{"
     local appendComma = false
-    if (vulnerableAppResponse.status == 200) then
+    if (carries_json(vulnerableAppResponse)) then
         response = response .. '"VulnerableApp":' .. vulnerableAppResponse.body
         appendComma = true
     end
-    if (llmForgeResponse and llmForgeResponse.status == 200) then
+    if (carries_json(llmForgeResponse)) then
         if (appendComma) then
             response = response .. ","
         end
         appendComma = true
         response = response .. '"llmforge":' .. llmForgeResponse.body
     end
-    if (vulnerableAppJspResponse.status == 200) then
+    if (carries_json(vulnerableAppJspResponse)) then
         if (appendComma) then
             response = response .. ","
         end
         appendComma = true
         response = response .. '"VulnerableApp-jsp":' .. vulnerableAppJspResponse.body
     end
-    if (vulnerableAppPhpResponse.status == 200) then
+    if (carries_json(vulnerableAppPhpResponse)) then
         if (appendComma) then
             response = response .. ","
         end

--- a/lua-modules/vulnerableapp_utility.lua
+++ b/lua-modules/vulnerableapp_utility.lua
@@ -1,15 +1,23 @@
+local cjson = require("cjson.safe")
+
 local vulnerableapp_utility = {}
 
 -- An app can answer 200 with a body that is not JSON. VulnerableApp-php does exactly that on the
 -- scanner endpoints, replying "/VulnerableApp-php/scanner/dast is not available" as text/html.
 -- Splicing such a body in produces a document that is not JSON at all, so the whole merged
 -- response becomes unreadable rather than one app being missing from it.
+--
+-- The body is decoded only to check it and is then discarded: the merge still splices the raw
+-- bytes, so each app's own key order and formatting reach the caller unchanged. A truncated body
+-- is refused because ngx.location.capture reports one with status 200 and a partial body, which
+-- can begin like JSON and still end mid-document. Only an object or an array is accepted, since
+-- the aggregate maps an app name to its findings and a bare number or string would satisfy the
+-- syntax without fitting that shape.
 local function carries_json(response)
-    if (not response or response.status ~= 200 or not response.body) then
+    if (not response or response.status ~= 200 or not response.body or response.truncated) then
         return false
     end
-    local first = response.body:match("^%s*(.)")
-    return first == "[" or first == "{"
+    return type(cjson.decode(response.body)) == "table"
 end
 
 function vulnerableapp_utility.merge_vulnerability_information(vulnerableAppResponse, vulnerableAppJspResponse, vulnerableAppPhpResponse, llmForgeResponse)

--- a/nginx.conf
+++ b/nginx.conf
@@ -94,7 +94,7 @@ http {
 			default_type 'application/json';
 			content_by_lua_block {
 				local vulnerableAppResponse, vulnerableAppJspResponse, vulnerableAppPhpResponse = ngx.location.capture_multi({
-					{ "/VulnerableApp/scanner" },
+					{ "/VulnerableApp/scanner/dast" },
 					{ "/VulnerableApp-jsp/scanner/dast" },
 					{ "/VulnerableApp-php/scanner/dast" }
 				})


### PR DESCRIPTION
Closes #122.

Two changes. The first is the one line this issue had left. The second is a defect I hit while checking the first, in the same two endpoints, and it corrects something I got wrong on the issue thread.

**`/scanner/dast` now captures the Java app at `/scanner/dast`**

The other two apps already pointed there. The Java one could not, because that endpoint did not exist yet. It landed as SasanLabs/VulnerableApp#733, so facade no longer has to call the bare path that answers with a `Deprecation` header.

The 153 entries under `VulnerableApp` are the same objects before and after, and with only this commit applied the whole merged response is byte for byte identical to `main`.

The full response does change once the second commit is in, by 69 bytes, because the malformed fragment described below stops being appended. That is the point of the second commit rather than a side effect of this one.

**The merge now skips a 200 response whose body is not JSON**

`VulnerableApp-php` answers both scanner paths with HTTP 200, `Content-Type: text/html`, and a body naming the path it was asked for, so `/VulnerableApp-php/scanner/dast is not available` for one and the `sast` wording for the other. I read that as the endpoint not being implemented there, but the observation is the status, the type and the body. `merge_vulnerability_information` only looked at the status, so that sentence was concatenated in where a JSON array was expected:

```
..."vulnerabilityTypes":["XXE"]}],"VulnerableApp-php":/VulnerableApp-php/scanner/dast is not available}
```

Both `/scanner/dast` and `/scanner/sast` therefore return something no JSON parser accepts, which would matter for the comparator proposed in SasanLabs/VulnerableApp#726, since that issue has facade as the thing it calls. That issue is still open and unimplemented, so nothing is broken by it today.

`/VulnerabilityDefinitions` is not affected today, because all three apps implement it and return JSON, and its response parses before and after this change. The guard is in the shared function rather than in the scanner blocks so that the next app to answer 200 with a message does not reopen this.

**Correcting my earlier comment**

In [my comment above](https://github.com/SasanLabs/VulnerableApp-facade/issues/122#issuecomment-5230024838) the scope table says, for degrading gracefully when an app is down, "present, responses whose status is not 200 are skipped". The reasoning in that second half is the incomplete part: skipping on status alone is not enough when an app answers 200 with something that is not JSON. The row holds for `/VulnerabilityDefinitions` and not for the scanner blocks. I had read the code rather than run it, which that comment did say, and running it is what showed the difference.

**How I checked it**

Against `docker-compose.without_llm.yml`, so `ENABLE_VULNERABLEAPP_JSP=true`, `ENABLE_VULNERABLEAPP_PHP=true`, `ENABLE_LLMFORGE=false`.

The published facade image bakes in its own `nginx.conf` and Lua module, and I checked that the baked `nginx.conf` is identical to `main`. Running the stack as is therefore measures `main`, which is the first column below. To measure this branch without rebuilding the image, mount the two changed files over it:

```
cat > override.yml <<'EOF'
services:
    VulnerableApp-facade:
      volumes:
       - ./nginx.conf:/usr/local/openresty/nginx/conf/nginx.conf:ro
       - ./lua-modules/vulnerableapp_utility.lua:/vulnerableapp_utility.lua:ro
EOF
mkdir -p templates
docker-compose -f docker-compose.without_llm.yml -f override.yml up -d
until curl -sf -o /dev/null http://localhost/VulnerableApp/; do sleep 3; done
curl -s http://localhost/scanner/dast | python3 -c 'import json,sys; d=json.load(sys.stdin); print({k: len(v) for k, v in d.items()})'
curl -s http://localhost/scanner/sast | python3 -c 'import json,sys; d=json.load(sys.stdin); print({k: len(v) for k, v in d.items()})'
```

Drop the `-f override.yml` to get the first column instead, where the two `curl` calls fail to parse rather than printing counts. The `mkdir` is there because `docker-compose.without_llm.yml` mounts `./templates`, which is not in the repository, and the `until` loop is because `up -d` returns before the Java application is serving.

| | on `main` | on this branch |
|---|---|---|
| `/scanner/dast` | does not parse, fails at character 26180 | parses, 153 entries |
| `/scanner/sast` | does not parse, fails at character 27967 | parses, 154 entries |
| `/VulnerabilityDefinitions` | parses | identical bytes to `main` |

One consequence worth stating rather than leaving to be discovered: `VulnerableApp-php` had a key in the merged scanner responses before this change, holding that sentence, and it has no key after. The merged object is `{"VulnerableApp": [...]}` alone on this stack, since jsp answers 404 and php answers a non-JSON body. That is the same shape `/VulnerabilityDefinitions` would take if those apps stopped returning JSON there.

The four scanner responses were each fetched twice and the two fetches were byte identical every time. The `/VulnerabilityDefinitions` row is one fetch per column, compared with `cmp`, not two. `VulnerableApp-jsp` returns 404 for both scanner paths, so it is left out of the merge on `main` and on this branch alike, which is the existing behaviour and not something this changes.

To confirm that config line is what selects the path rather than something else, I pointed it at a path that does not exist and the `VulnerableApp` key disappeared from the response, leaving 71 bytes.

`luacheck .` in `lua-modules/` reports 0 warnings and 0 errors over 1 file. That is the command the Compile workflow runs, though I ran it in an Alpine container rather than on the workflow's Ubuntu runner.

**Two things worth saying plainly**

`carries_json` decodes the body with OpenResty's bundled `cjson.safe` and accepts it only when the result is an object or an array. It also refuses a response the subrequest reported as truncated. The decoded value is thrown away and the merge still splices the raw bytes, so each app's own key order and formatting reach the caller unchanged.

It started as a check on the first non-space character, which was enough to keep the php sentence out but let `{error}` and a body cut off part way through slip past. The automated review on this PR raised both, and the third commit fixes them. Output on this stack does not move: all three endpoints are byte for byte identical to the second commit.

The `llmforge` path is unchanged but I did not exercise it, since the stack I ran sets `ENABLE_LLMFORGE=false`. You said on the issue that DAST and SAST for LLMForge are worth skipping for now, so the scanner blocks still capture three apps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scan result handling by excluding truncated, invalid, empty, or non-JSON responses from aggregated results.
  * Corrected the dynamic application security testing scan endpoint to return the intended results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
